### PR TITLE
Fix some issues in StreamOps.intersection()

### DIFF
--- a/src/main/java/com/scottshipp/code/mill/stream/StreamOps.java
+++ b/src/main/java/com/scottshipp/code/mill/stream/StreamOps.java
@@ -60,19 +60,7 @@ public final class StreamOps {
      * in the returned stream each exist in all of the passed streams
      */
     public static <T> Stream<T> intersection(Stream<T>... streams) {
-        if(streams.length < 1) {
-            return Stream.empty();
-        } else {
-            return intersection(streams[0], Arrays.copyOfRange(streams, 1, streams.length));
-        }
-    }
-
-    private static <T> Stream<T> intersection(Stream<T> result, Stream<T>... streams) {
-        if(streams.length < 2) {
-            return intersection(result, streams[0]);
-        } else {
-            return intersection(result, Arrays.copyOfRange(streams, 1, streams.length - 1));
-        }
+        return Stream.of(streams).reduce(StreamOps::intersection).orElseGet(Stream::empty);
     }
 
     private static <T> Stream<T> intersection(Stream<T> stream1, Stream<T> stream2) {

--- a/src/test/java/com/scottshipp/code/mill/stream/StreamOpsTest.java
+++ b/src/test/java/com/scottshipp/code/mill/stream/StreamOpsTest.java
@@ -95,6 +95,11 @@ public class StreamOpsTest {
     }
 
     @Test
+    public void testIntersectionOfOneStream() {
+        assertEquals(0, StreamOps.intersection(Stream.empty()).count());
+    }
+
+    @Test
     public void testIntersectionOfTwoStreams() {
         Stream<String> engineeringTeam1 = Stream.of(
                 "Shannon Smith", "Riley Joson",

--- a/src/test/java/com/scottshipp/code/mill/stream/StreamOpsTest.java
+++ b/src/test/java/com/scottshipp/code/mill/stream/StreamOpsTest.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class StreamOpsTest {
@@ -145,6 +144,17 @@ public class StreamOpsTest {
                 StreamOps.intersection(engineeringTeam1, engineeringTeam2, hiringManagers, barRaisers)
                         .collect(Collectors.joining(", "))
         );
+    }
+
+    @Test
+    public void testSpecificIncorrectImplementationOfIntersection() {
+        assertEquals(1,
+                StreamOps.intersection(
+                        Stream.of(1, 2, 3),
+                        Stream.of(1),
+                        Stream.of(1, 2, 3),
+                        Stream.of(1, 2, 3)
+                ).count());
     }
 
     @Test


### PR DESCRIPTION
Previously, it was throwing ArrayIndexOutOfBounds when an odd number of streams is passed in, and only the first stream, and the (n/2+1)th element were intersected.